### PR TITLE
Expose Message to bots

### DIFF
--- a/conversation.go
+++ b/conversation.go
@@ -14,6 +14,7 @@ type ConversationInterface interface {
 	String(name string) (string, error)
 	Reply(text string, a ...interface{})
 	Match(position int) (string, error)
+	Message() MessageInterface
 
 	SetConnection(connection Connection)
 
@@ -33,6 +34,10 @@ type Conversation struct {
 	socket  *websocket.Conn
 
 	connection Connection
+}
+
+func (c *Conversation) Message() MessageInterface {
+	return c.message
 }
 
 func (c *Conversation) send(msg MessageInterface) {


### PR DESCRIPTION
My use case is that I want my bot to know who it's talking to and on which channel, for authorisation purposes. This PR exposes `MessageInterface.User()` to bots via `ConversationInterface.Message()`. The channel is not exposed, since that's not in the Message interface. 

Any thoughts? 